### PR TITLE
add sort -V to the tag retrival

### DIFF
--- a/.github/workflows/rpi4-kernel-build.yml
+++ b/.github/workflows/rpi4-kernel-build.yml
@@ -124,7 +124,7 @@ jobs:
       - name: checkout necessary tag
         run: |
           cd $HOME/linux_build/${KERNEL_DIR} \
-          && git tag -l *`cat $HOME/uname_r | cut -d '-' -f 2`* | tail -1 > $HOME/linux_build/tag \
+          && git tag -l *`cat $HOME/uname_r | cut -d '-' -f 2`* | sort -V | tail -1 > $HOME/linux_build/tag \
           && git checkout `cat $HOME/linux_build/tag`
 
       - name: Retrieve buildinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN mkdir /home/user/linux_build \
 
 # checkout necessary tag
 RUN cd /home/user/linux_build/${KERNEL_DIR} \
-    && git tag -l *`cat /home/user/uname_r | cut -d '-' -f 2`* | tail -1 > /home/user/linux_build/tag \
+    && git tag -l *`cat /home/user/uname_r | cut -d '-' -f 2`* | sort -V | tail -1 > /home/user/linux_build/tag \
     && git checkout `cat /home/user/linux_build/tag`
 
 # install buildinfo to retieve `raspi` kernel config


### PR DESCRIPTION
The results of the tag retrieval shall be sorted by version, otherwise, the wrong tag could be picked up