### PR TITLE
set by default LTTNG to 2.13

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       lttng_version:
-        description: 'LTTNG version, 2.12|2.13'
+        description: 'LTTNG version, 2.13'
         required: false
         type: string
 

--- a/.github/workflows/build-stable.yaml
+++ b/.github/workflows/build-stable.yaml
@@ -17,7 +17,7 @@ on:
         default: '5.4.0-1058-raspi'
         type: string
       lttng_version:
-        description: 'LTTNG version 2.12|2.13'
+        description: 'LTTNG version 2.13'
         required: false
         type: string
 jobs:

--- a/.github/workflows/rpi4-kernel-build.yml
+++ b/.github/workflows/rpi4-kernel-build.yml
@@ -34,7 +34,7 @@ on:
         type: string
       lttng_version:
         description: 'LTTNG version'
-        default: '2.12'
+        default: '2.13'
         required: false
         type: string
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 #     see http://ports.ubuntu.com/pool/main/l/linux-raspi/
 #   <RT patch> is in a form of 5.4.177-rt69, if not defined the closest to the defined <raspi release> is taken
 #     see http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.4/older
-#   <LTTNG version> is 2.12 or 2.13, default is 2.12
+#   <LTTNG version> is 2.13, default is 2.13
 #
 # To build a Docker image for the latest 5.4 raspi kernel run
 # $ docker build -t rtwg-image .
@@ -53,7 +53,7 @@ ARG RT_PATCH
 ARG triple=aarch64-linux-gnu
 ARG KERNEL_VERSION=5.4.0
 ARG UBUNTU_VERSION=focal
-ARG LTTNG_VERSION=2.12
+ARG LTTNG_VERSION=2.13
 ARG KERNEL_DIR=linux-raspi
 
 # setup arch

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ where:
 * ```<kernel version>``` is `5.4.0` or `5.15.0`, default is `5.4.0`
 * ```<raspi release>``` is in a form of ```5.4.0-1058-raspi```,  see [Ubuntu raspi Linux kernels](http://ports.ubuntu.com/pool/main/l/linux-raspi)
 * ```<RT patch>``` is in a form of ```5.4.177-rt69```, see [RT patches](http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.4/older)
-* ```<LTTNG version>``` is `2.12` or `2.13`, default is `2.12`
+* ```<LTTNG version>``` is `2.13`, default is `2.13`
 
 ```bash
 docker run -t -i rtwg-image bash


### PR DESCRIPTION
Kernel build fails while using LTTNG 2.12, see https://github.com/ros-realtime/linux-real-time-kernel-builder/issues/45. There are backport patches needed. We do not plan to patch LTTNG 2.12. Set by default LTTNG to 2.13 instead.