### PR TITLE
Use Dockerfile in the github actions instead of plain yaml file

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -5,14 +5,17 @@ on:
     inputs:
       kernel_version:
         description: 'Raspi kernel version, 5.4.0|5.15.0'
+        default: '5.15.0'
         required: false
         type: string
       ubuntu_version:
         description: 'Ubuntu version, focal|jammy'
+        default: 'jammy'
         required: false
         type: string
       lttng_version:
         description: 'LTTNG version, 2.13'
+        default: '2.13'
         required: false
         type: string
 

--- a/.github/workflows/build-stable.yaml
+++ b/.github/workflows/build-stable.yaml
@@ -5,19 +5,22 @@ on:
     inputs:
       kernel_version:
         description: 'Raspi kernel version, 5.4.0|5.15.0'
+        default: '5.15.0'
         required: false
         type: string
       ubuntu_version:
         description: 'Ubuntu version, focal|jammy'
+        default: 'jammy'
         required: false
         type: string
       uname_r:
-        description: 'raspi release in a form of <5.4.0-1058-raspi>'
+        description: 'raspi release in a form of <5.15.0-1012-raspi>'
         required: true
-        default: '5.4.0-1058-raspi'
+        default: '5.15.0-1012-raspi'
         type: string
       lttng_version:
         description: 'LTTNG version 2.13'
+        default: '2.13'
         required: false
         type: string
 jobs:

--- a/.github/workflows/rpi4-kernel-build.yml
+++ b/.github/workflows/rpi4-kernel-build.yml
@@ -52,7 +52,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get available space
         # We need at least 20GB to build kernel plus some space for the dependencies
@@ -188,7 +188,7 @@ jobs:
           cd $HOME/linux_build/${KERNEL_DIR} \
           && make ARCH=${ARCH} CROSS_COMPILE=${triple}- LOCALVERSION=-raspi -j `nproc` bindeb-pkg
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: 'RPI4 RT Kernel deb packages'
           path: ~/linux_build/*.deb

--- a/.github/workflows/rpi4-kernel-build.yml
+++ b/.github/workflows/rpi4-kernel-build.yml
@@ -3,7 +3,6 @@
 # The build takes 1.5 hours and artifacts are available under workflow artifacts
 #  - kernel .deb packages
 # TODO:
-#  - use Dockerfile instead
 #  - create Docker image and push it to the packages
 
 name: 'RPI4 RT Kernel build'
@@ -13,23 +12,23 @@ on:
   workflow_call:
     inputs:
       uname_r:
-        description: 'raspi release in a form of <5.4.0-1058-raspi>'
+        description: 'raspi release in a form of <5.15.0-1023-raspi>'
         default: ''
         required: false
         type: string
       rt_patch:
-        description: 'RT patch in a form of <5.4.177-rt69>'
+        description: 'RT patch in a form of <5.15.76-rt53>'
         default: ''
         required: false
         type: string
       kernel_version:
         description: 'Raspi kernel version'
-        default: '5.4.0'
+        default: '5.15.0'
         required: false
         type: string
       ubuntu_version:
         description: 'Ubuntu version'
-        default: 'focal'
+        default: 'jammy'
         required: false
         type: string
       lttng_version:
@@ -46,8 +45,8 @@ env:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # Use Ubuntu 20.04 runner
-    runs-on: ubuntu-20.04
+    # Use Ubuntu 22.04 runner
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -55,141 +54,42 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Get available space
-        # We need at least 20GB to build kernel plus some space for the dependencies
         run: |
           cd /
           df -H
 
-      - name: Get a list of the installed packages
-        # We might probably delete some of them to increase free space
+      - name: Print input params
         run: |
-          sudo apt-get update
-          apt list --installed
+          echo UBUNTU_VERSION=${{ inputs.ubuntu_version }}
+          echo KERNEL_VERSION=${{ inputs.kernel_version }}
+          echo UNAME_R=${{ inputs.uname_r }}
+          echo RT_PATCH=${{ inputs.rt_patch }}
+          echo LTTNG_VERSION=${{ inputs.lttng_version }}
 
-      - name: Increase free space
-        # Remove Android and dotnet
-        run: |
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-          ls /usr/local/
-
-      - name: Get available size (again)
-        run: |
-          cd /
-          df -H
-
-      - name: Install deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -q -y tzdata apt-utils lsb-release software-properties-common
-          sudo rm -rf /var/lib/apt/lists/*
-
-      - name: Setup ARCH repos
-        run: |
-          sudo apt-get update
-          sudo apt-get install -q -y gcc-${triple}
-          sudo dpkg --add-architecture ${ARCH}
-          sudo sed -i 's/deb h/deb [arch=amd64] h/g' /etc/apt/sources.list
-          sudo add-apt-repository -n -s "deb [arch=$ARCH] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -s -c) main universe restricted"
-          sudo add-apt-repository -n -s "deb [arch=$ARCH] http://ports.ubuntu.com/ubuntu-ports $(lsb_release -s -c)-updates main universe restricted"
-          sudo rm -rf /var/lib/apt/lists/*
-
-      - name: Install extra packages needed for the patch handling
-        run: |
-          sudo apt-get update
-          sudo apt-get install -q -y wget curl gzip
-          sudo rm -rf /var/lib/apt/lists/*
-
-      - name: Setup uname_r
-        run: |
-         UNAME_R=${{ inputs.uname_r }}
-         if test -z $UNAME_R; then UNAME_R=`curl -s http://ports.ubuntu.com/pool/main/l/linux-raspi/ | grep linux-buildinfo | grep -o -P '(?<=<a href=").*(?=">l)' | grep ${ARCH} | grep ${{ inputs.kernel_version }} | sort | tail -n 1 | cut -d '-' -f 3-4`-raspi; fi \
-         && echo $UNAME_R > $HOME/uname_r
-
-      - name: Install build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get build-dep -q -y linux
-          sudo apt-get install -q -y \
-          libncurses-dev flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf fakeroot
-          sudo rm -rf /var/lib/apt/lists/*
-
-      - name: Install linux sources
-        run: |
-          mkdir $HOME/linux_build && cd $HOME/linux_build \
-          && time git clone -b master --single-branch https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux-raspi/+git/${{ inputs.ubuntu_version }} ${KERNEL_DIR} \
-          && cd ${KERNEL_DIR} \
-          && git fetch --tag
-
-      - name: checkout necessary tag
-        run: |
-          cd $HOME/linux_build/${KERNEL_DIR} \
-          && git tag -l *`cat $HOME/uname_r | cut -d '-' -f 2`* | sort -V | tail -1 > $HOME/linux_build/tag \
-          && git checkout `cat $HOME/linux_build/tag`
-
-      - name: Retrieve buildinfo
-        run: |
-          # install buildinfo to retrieve `raspi` kernel config
-          cd $HOME \
-          && wget http://ports.ubuntu.com/pool/main/l/linux-raspi/linux-buildinfo-${{ inputs.kernel_version }}-`cat $HOME/uname_r | cut -d '-' -f 2`-raspi_${{ inputs.kernel_version }}-`cat $HOME/linux_build/tag | cut -d '-' -f 4`_${ARCH}.deb \
-          && dpkg -X *.deb $HOME
-
-      - name: Get the nearest RT patch to the kernel SUBLEVEL
-        run: |
-          cd $HOME/linux_build/${KERNEL_DIR}
-          RT_PATCH=${{ inputs.rt_patch }}
-          if test -z $RT_PATCH; then $GITHUB_WORKSPACE/getpatch.sh `make kernelversion` > $HOME/rt_patch; else echo $RT_PATCH > $HOME/rt_patch; fi
-
-      - name: Download and unzip RT patch, the closest to the RPI kernel version
-        run: |
-          cd $HOME/linux_build
-          wget http://cdn.kernel.org/pub/linux/kernel/projects/rt/`echo ${{ inputs.kernel_version }} | cut -d '.' -f 1-2`/older/patch-`cat $HOME/rt_patch`.patch.gz \
-          && gunzip patch-`cat $HOME/rt_patch`.patch.gz
-
-      - name: Download lttng source for use later
-        run: |
-          cd $HOME
-          sudo apt-add-repository -s -y ppa:lttng/stable-${{ inputs.lttng_version }} \
-          && sudo apt-get update \
-          && apt-get source -y -q lttng-modules-dkms
-
-      - name:  run lttng built-in script to configure RT kernel
-        run: |
-          cd $HOME \
-          && cd `ls -d lttng-*/` \
-          && ./scripts/built-in.sh ${HOME}/linux_build/${KERNEL_DIR}
-
-      - name: Patch raspi kernel, do not fail if some patches are skipped
-        run: |
-          cd $HOME/linux_build/${KERNEL_DIR} \
-          && OUT="$(patch -p1 --forward < ../patch-`cat $HOME/rt_patch`.patch)" || echo "${OUT}" | grep "Skipping patch" -q || (echo "$OUT" && false);
-
-      - name: Setup build environment
-        run: |
-          cd $HOME/linux_build/${KERNEL_DIR} \
-          && export $(dpkg-architecture -a${ARCH}) \
-          && export CROSS_COMPILE=${triple}- \
-          && fakeroot debian/rules clean \
-          && LANG=C fakeroot debian/rules printenv
-
-      - name: Config RT kernel and merge config fragment
-        run: |
-          cd $HOME/linux_build/${KERNEL_DIR} \
-          && cp $HOME/usr/lib/linux/`cat $HOME/uname_r`/config .config \
-          && ARCH=${ARCH} CROSS_COMPILE=${triple}- ./scripts/kconfig/merge_config.sh .config $GITHUB_WORKSPACE/.config-fragment
-
-      - name: Clean debian/rules
-        run: |
-          cd $HOME/linux_build/${KERNEL_DIR} \
-          && fakeroot debian/rules clean
+      - name: Build rtwg-image docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            UBUNTU_VERSION=${{ inputs.ubuntu_version }}
+            KERNEL_VERSION=${{ inputs.kernel_version }}
+            UNAME_R=${{ inputs.uname_r }}
+            RT_PATCH=${{ inputs.rt_patch }}
+            LTTNG_VERSION=${{ inputs.lttng_version }}
+          push: false
+          tags: rtwg-image:22.04
 
       - name: Build kernel
-        run: |
-          cd $HOME/linux_build/${KERNEL_DIR} \
-          && make ARCH=${ARCH} CROSS_COMPILE=${triple}- LOCALVERSION=-raspi -j `nproc` bindeb-pkg
+        uses: addnab/docker-run-action@v3
+        with:
+          image: rtwg-image:22.04
+          options: -v ${{ github.workspace }}:/work
+          run:  |
+            cd /home/user/linux_build/linux-raspi
+            make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- LOCALVERSION=-raspi -j `nproc` bindeb-pkg
+            sudo cp ../*.deb /work
 
       - uses: actions/upload-artifact@v3
         with:
           name: 'RPI4 RT Kernel deb packages'
-          path: ~/linux_build/*.deb
-
+          path: ${{ github.workspace }}/*.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,25 @@
 # A Dockerfile to build an RT kernel for the RPI4 based on Ubuntu 20.04 or 22.04 RPI4 kernel
 #
-# If run without parameters the Docker image is created to built RT_PREEMPT patched version of the latest 5.4 raspi kernel
+# If run without parameters the Docker image is created to built RT_PREEMPT patched version of the latest 5.15 raspi kernel
 # The Docker build command accepts the following build arguments:
 # $ docker build [--build-arg UBUNTU_VERSION=<ubuntu name>] [--build-arg KERNEL_VERSION=<kernel version>]
 #                [--build-arg UNAME_R=<raspi release>] [--build-arg RT_PATCH=<RT patch>]
 #                [--build-arg LTTNG_VERSION=<LTTNG version>] -t rtwg-image .
 #
 # where
-#   <ubuntu name> is jammy or focal, default is focal
-#   <kernel version> is 5.4.0 or 5.15.0, default is 5.4.0
-#   <raspi release> is in a form of 5.4.0-1058-raspi, if not defined the lastest version is taken
+#   <ubuntu name> is jammy or focal, default is jammy
+#   <kernel version> is 5.4.0 or 5.15.0, default is 5.15.0
+#   <raspi release> is in a form of 5.15.0-1023-raspi, if not defined the lastest version is taken
 #     see http://ports.ubuntu.com/pool/main/l/linux-raspi/
-#   <RT patch> is in a form of 5.4.177-rt69, if not defined the closest to the defined <raspi release> is taken
-#     see http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.4/older
+#   <RT patch> is in a form of 5.15.76-rt53, if not defined the closest to the defined <raspi release> is taken
+#     see http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.15/older
 #   <LTTNG version> is 2.13, default is 2.13
 #
-# To build a Docker image for the latest 5.4 raspi kernel run
+# To build a Docker image for the latest 5.15 raspi kernel run
 # $ docker build -t rtwg-image .
 #
-# To build a Docker image for the latest 5.15 raspi kernel run
-# $ docker build --build-arg UBUNTU_VERSION=jammy --build-arg KERNEL_VERSION=5.15.0 --build-arg LTTNG_VERSION=2.13 -t rtwg-image .
+# To build a Docker image for the latest 5.4 raspi kernel run
+# $ docker build --build-arg UBUNTU_VERSION=focal --build-arg KERNEL_VERSION=5.4.0 -t rtwg-image .
 #
 # After that the Docker image is prepared and ready to run
 # $ docker run -it rtwg-image bash
@@ -29,9 +29,9 @@
 # $ make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- LOCALVERSION=-raspi -j `nproc` bindeb-pkg
 #
 # user ~/linux_build/linux-raspi $ ls -la ../*.deb
-# -rw-r--r-- 1 user user  11442412 Apr  8 13:20 ../linux-headers-5.4.174-rt69-raspi_5.4.174-rt69-raspi-1_arm64.deb
-# -rw-r--r-- 1 user user  40261364 Apr  8 13:21 ../linux-image-5.4.174-rt69-raspi_5.4.174-rt69-raspi-1_arm64.deb
-# -rw-r--r-- 1 user user   1055452 Apr  8 13:20 ../linux-libc-dev_5.4.174-rt69-raspi-1_arm64.deb
+# -rw-r--r-- 1 user user   8123580 Jan 16 16:34 ../linux-headers-5.15.74-rt53-raspi_5.15.74-rt53-raspi-1_arm64.deb
+# -rw-r--r-- 1 user user  58802024 Jan 16 16:34 ../linux-image-5.15.74-rt53-raspi_5.15.74-rt53-raspi-1_arm64.deb
+# -rw-r--r-- 1 user user   1185420 Jan 16 16:34 ../linux-libc-dev_5.15.74-rt53-raspi-1_arm64.deb
 #
 # copy deb packages to the host, or directly to the RPI4 target
 # $ scp ../*.deb <user>@172.17.0.1:/home/<user>/.
@@ -51,8 +51,8 @@ ARG ARCH=arm64
 ARG UNAME_R
 ARG RT_PATCH
 ARG triple=aarch64-linux-gnu
-ARG KERNEL_VERSION=5.4.0
-ARG UBUNTU_VERSION=focal
+ARG KERNEL_VERSION=5.15.0
+ARG UBUNTU_VERSION=jammy
 ARG LTTNG_VERSION=2.13
 ARG KERNEL_DIR=linux-raspi
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ docker build [--no-cache] [--build-arg UBUNTU_VERSION=<ubuntu name>] [--build-ar
 
 where:
 
-* ```<ubuntu name>``` is `jammy` or `focal`, default is `focal`
-* ```<kernel version>``` is `5.4.0` or `5.15.0`, default is `5.4.0`
-* ```<raspi release>``` is in a form of ```5.4.0-1058-raspi```,  see [Ubuntu raspi Linux kernels](http://ports.ubuntu.com/pool/main/l/linux-raspi)
-* ```<RT patch>``` is in a form of ```5.4.177-rt69```, see [RT patches](http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.4/older)
+* ```<ubuntu name>``` is `jammy` or `focal`, default is `jammy`
+* ```<kernel version>``` is `5.15.0` or `5.4.0`, default is `5.15.0`
+* ```<raspi release>``` is in a form of ```5.15.0-1023-raspi```,  see [Ubuntu raspi Linux kernels](http://ports.ubuntu.com/pool/main/l/linux-raspi)
+* ```<RT patch>``` is in a form of ```5.15.76-rt53```, see [RT patches](http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.15/older)
 * ```<LTTNG version>``` is `2.13`, default is `2.13`
 
 ```bash
@@ -112,19 +112,19 @@ You need 16GB free disk space to build it, it takes a while, and the results are
 
 ```bash
 raspi:~/linux_build/linux-raspi $ ls -la ../*.deb
--rw-r--r-- 1 user user  11442412 Apr  8 13:20 ../linux-headers-5.4.174-rt69-raspi_5.4.174-rt69-raspi-1_arm64.deb
--rw-r--r-- 1 user user  40261364 Apr  8 13:21 ../linux-image-5.4.174-rt69-raspi_5.4.174-rt69-raspi-1_arm64.deb
--rw-r--r-- 1 user user   1055452 Apr  8 13:20 ../linux-libc-dev_5.4.174-rt69-raspi-1_arm64.deb
+-rw-r--r-- 1 user user   8123580 Jan 16 16:34 ../linux-headers-5.15.74-rt53-raspi_5.15.74-rt53-raspi-1_arm64.deb
+-rw-r--r-- 1 user user  58802024 Jan 16 16:34 ../linux-image-5.15.74-rt53-raspi_5.15.74-rt53-raspi-1_arm64.deb
+-rw-r--r-- 1 user user   1185420 Jan 16 16:34 ../linux-libc-dev_5.15.74-rt53-raspi-1_arm64.deb
 ```
 
 ## Deploy new kernel on Raspberry Pi4
 
-### Download and install Ubuntu 20.04 server image
+### Download and install Ubuntu 22.04 server image
 
-Follow these links to download and install Ubuntu 20.04 on your Raspberry Pi4
+Follow these links to download and install Ubuntu 22.04 on your Raspberry Pi4
 
 * [Install Ubuntu on a Raspberry Pi](https://ubuntu.com/download/raspberry-pi)
-* [Download Ubuntu Raspberry Pi server image](https://ubuntu.com/download/raspberry-pi/thank-you?version=20.04.3&architecture=server-arm64+raspi)
+* [Download Ubuntu Raspberry Pi server image](https://ubuntu.com/download/raspberry-pi/thank-you?version=22.04.1&architecture=server-arm64+raspi)
 * [Create an Ubuntu image for a Raspberry Pi on Ubuntu](https://ubuntu.com/tutorials/create-an-ubuntu-image-for-a-raspberry-pi-on-ubuntu#2-on-your-ubuntu-machine)
 
 ```bash
@@ -163,7 +163,7 @@ After reboot you should see a new RT kernel installed and real-time enabled
 
 ```bash
 ubuntu@ubuntu:~$ uname -a
-Linux ubuntu 5.4.174-rt69-raspi #1 SMP PREEMPT_RT Mon Apr 8 14:10:16 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
+Linux ubuntu 5.15.74-rt53-raspi #1 SMP PREEMPT_RT Mon Jan 16 14:10:16 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux
 
 ubuntu@ubuntu:~$ cat /sys/kernel/realtime
 1
@@ -183,6 +183,6 @@ As this repository is within the `ros-realtime` organization it can be assumed t
 
 * [ROS Real-Time Working group documentation](https://ros-realtime.github.io/Guides/Real-Time-Operating-System-Setup/Real-Time-Linux/rt_linux_index.html)
 * [Ubuntu raspi linux images](http://ports.ubuntu.com/pool/main/l/linux-raspi)
-* [RT patches](http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.4/older)
-* [Download Ubuntu raspi image](https://ubuntu.com/download/raspberry-pi/thank-you?version=20.04&architecture=arm64+raspi)
+* [RT patches](http://cdn.kernel.org/pub/linux/kernel/projects/rt/5.15/older)
+* [Download Ubuntu raspi server image](https://ubuntu.com/download/raspberry-pi/thank-you?version=22.04.1&architecture=server-arm64+raspi)
 * [Building Realtime ```RT_PREEMPT``` kernel for ROS 2](https://index.ros.org/doc/ros2/Tutorials/Building-Realtime-rt_preempt-kernel-for-ROS-2/)


### PR DESCRIPTION
this PR unifies the creation of a Docker container for the Linux kernel build.  GH action has implemented its own container which has introduced a duplication. Now the same Dockerfile is used for the GH actions as well.