### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/rpi4-kernel-build.yml
+++ b/.github/workflows/rpi4-kernel-build.yml
@@ -100,7 +100,7 @@ jobs:
             make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- LOCALVERSION=-raspi -j `nproc` bindeb-pkg
             sudo cp ../*.deb /work
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: 'RPI4 RT Kernel deb packages'
           path: ${{ github.workspace }}/*.deb


### PR DESCRIPTION
v3 has been deprecated:

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/